### PR TITLE
Resume input overflow problem solved

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -283,3 +283,7 @@ td.header {
 #notice a {
 	color: #F1C40F;
 }
+.superlist {
+	font-family: 'Times New Roman', Times, serif;
+	font-size: 2rem;
+}

--- a/css/main.css
+++ b/css/main.css
@@ -50,6 +50,7 @@ body {
 	box-shadow: 0px 0px 20px 0px #000;
 	line-height: 1.4em;
 	text-align: left;
+	word-wrap:break-word;
 }
 
 

--- a/index.html
+++ b/index.html
@@ -179,6 +179,7 @@
 
 				<h3 class="text-center">Lists and points</h3>
 				<button class="btn btn-block btn-xs btn-success" onclick="insertList();">+ Insert sub-list</button>
+				<button class="btn btn-block btn-xs btn-success superlist" onclick="insertsuperList();">+ Insert super-list</button>
 				<button class="btn btn-block btn-xs btn-warning" onclick="decreaseIndent();">&lt;&lt; Decrese indentation</button>
 				<button class="btn btn-block btn-xs btn-warning" onclick="increaseIndent();">&gt;&gt; Increase indentation</button>
 				<h5>


### PR DESCRIPTION
This problem results in overflow of text outside the resume template. A simple change in the css property removes the bug.